### PR TITLE
Add support for attribute parameters

### DIFF
--- a/lib/garoon-cat/request.rb
+++ b/lib/garoon-cat/request.rb
@@ -57,10 +57,10 @@ class GaroonCat::Request
       target.each do |key, v1|
         case v1
         when String
-          parameters.add_element(key.to_s).add_text(v1.to_s)
+          add_attribute_or_element!(parameters, key, v1)
         when Array
           v1.each do |v2|
-            parameters.add_element(key.to_s).add_text(v2.to_s)
+            add_attribute_or_element!(parameters, key, v2)
           end
         end
       end
@@ -97,6 +97,19 @@ class GaroonCat::Request
 
   def to_s
     doc.to_s
+  end
+
+  private
+
+  # @param element [REXML::Element]
+  # @param key [String, Symbol]
+  # @param value [String]
+  def add_attribute_or_element!(element, key, value)
+    if key[0] == "@"
+      element.root.add_attribute(key[1..-1].to_s, value)
+    else
+      element.add_element(key.to_s).add_text(value.to_s)
+    end
   end
 
 end

--- a/test/garoon-cat_test.rb
+++ b/test/garoon-cat_test.rb
@@ -56,6 +56,10 @@ class GaroonCat::Test < Minitest::Test
     @@users ||= @@garoon.service(:base).get_users_by_id(user_id:organization_ids)
   end
 
+  def events(params)
+    @@events ||= @@garoon.service(:schedule).get_events(params)
+  end
+
   def test_organization_ids
     assert_instance_of(Array, organization_ids)
   end
@@ -70,6 +74,14 @@ class GaroonCat::Test < Minitest::Test
 
   def test_users
     assert_instance_of(Hash, users)
+  end
+
+  def test_events_with_string_parameters
+    assert_instance_of(Hash, events('@start': '2018-08-25T00:00:00', '@end': '2018-08-26T00:00:00'))
+  end
+
+  def test_events_with_symbol_parameters
+    assert_instance_of(Hash, events(:@start => '2018-08-25T00:00:00', :@end => '2018-08-26T00:00:00'))
   end
 
 end


### PR DESCRIPTION
The request parameter of `ScheduleGetEvents` API are attributes parameters begging with the letter `@`.

ref:
https://developer.cybozu.io/hc/ja/articles/202463180